### PR TITLE
Improve test coverage

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,8 +4,13 @@ import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { FormsModule } from '@angular/forms';
 import { Todo } from './todo';
+import { TodoDataService } from './todo-data.service';
 
 describe('AppComponent', () => {
+  let fixture;
+  let app;
+  let todoDataService;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -14,25 +19,44 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent
       ],
+      providers: [TodoDataService]
     });
   });
 
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(AppComponent);
+    app = fixture.debugElement.componentInstance;
+    todoDataService = fixture.debugElement.injector.get(TodoDataService);
+  }));
+
   it('should create the app', async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    let app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
   }));
 
   it(`should have a newTodo todo`, async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    let app = fixture.debugElement.componentInstance;
     expect(app.newTodo instanceof Todo).toBeTruthy()
   }));
 
   it('should display "Todos" in h1 tag', async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
     let compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('h1').textContent).toContain('Todos');
+  }));
+
+  it('should add a todo', async(() => {
+    spyOn(todoDataService, 'addTodo');
+    app.addTodo();
+    expect(todoDataService.addTodo).toHaveBeenCalled();
+  }));
+
+  it('should complete a todo', async(() => {
+    spyOn(todoDataService, 'toggleTodoComplete');
+    app.toggleTodoComplete();
+    expect(todoDataService.toggleTodoComplete).toHaveBeenCalled();
+  }));
+
+  it('should remove a todo', async(() => {
+    spyOn(todoDataService, 'deleteTodoById');
+    app.removeTodo(1);
+    expect(todoDataService.deleteTodoById).toHaveBeenCalled();
   }));
 });


### PR DESCRIPTION
This PR improves the app's test coverage, bringing it almost to 100%. I couldn't find a way to test [`get todos()` in `app.component.ts`](https://github.com/addyosmani/todomvc-angular-4/blob/127eca9fe309dc34cbc8977f788a13d31a7c749c/src/app/app.component.ts#L31), but if you have a suggestion I could test that getter, which would bringing code coverage to 100%.